### PR TITLE
Oro 6.0.x compatibility added

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         }
     ],
     "require": {
-        "php": ">=8.2",
-        "oro/commerce": "5.1.*"
+        "php": "~8.3.0",
+        "oro/commerce": "6.0.*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~3.13.2",

--- a/src/Decorator/MatrixGridOrderManagerDecorator.php
+++ b/src/Decorator/MatrixGridOrderManagerDecorator.php
@@ -38,7 +38,7 @@ class MatrixGridOrderManagerDecorator extends MatrixGridOrderManager
      * Gets the matrix from the instance to be decorated and remove the rows and columns
      * for which there are no variant products
      */
-    public function getMatrixCollection(Product $product, ShoppingList $shoppingList = null): MatrixCollection
+    public function getMatrixCollection(Product $product, ?\Oro\Bundle\ShoppingListBundle\Entity\ShoppingList $shoppingList = null): MatrixCollection
     {
         $matrixCollection = $this->decorated->getMatrixCollection($product, $shoppingList);
 


### PR DESCRIPTION
This PR can be used as a starting point for the extension upgrade.
Most of the changes were done automatically with the upgrade-toolkit tool.

Here is a short list of done changes:
- Updated requirements to oro/commerce 6.0.*
- oro/upgrade-toolkit automatic migrations applied
